### PR TITLE
Added homepage to podspec file to fix pod install failure

### DIFF
--- a/ios/RNIdnow.podspec
+++ b/ios/RNIdnow.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNIdnow
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/bitwala/react-native-idnow"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
Fixed pod install failure if no homepage is completed in the podspec file:

`!] The `RNIdnow` pod failed to validate due to 1 error:

    - ERROR | attributes: Missing required attribute `homepage`.`