### PR TITLE
fix: non-IDNow camera access

### DIFF
--- a/android/src/main/java/com/bitwala/idnow/RNIdnowModule.java
+++ b/android/src/main/java/com/bitwala/idnow/RNIdnowModule.java
@@ -25,22 +25,24 @@ public class RNIdnowModule extends ReactContextBaseJavaModule {
     private final ActivityEventListener idnowActivityEventListener = new BaseActivityEventListener() {
         @Override
         public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent intent) {
-            switch (resultCode) {
+            if (requestCode == IDnowSDK.REQUEST_ID_NOW_SDK) {
+                switch (resultCode) {
 
-                case IDnowSDK.RESULT_CODE_SUCCESS:
-                    idnowPromise.resolve(true);
-                    break;
+                    case IDnowSDK.RESULT_CODE_SUCCESS:
+                        idnowPromise.resolve(true);
+                        break;
 
-                case IDnowSDK.RESULT_CODE_CANCEL:
-                    idnowPromise.reject("CANCELLED", "Identification canceled");
-                    break;
+                    case IDnowSDK.RESULT_CODE_CANCEL:
+                        idnowPromise.reject("CANCELLED", "Identification canceled");
+                        break;
 
-                case IDnowSDK.RESULT_CODE_FAILED:
-                    idnowPromise.reject("FAILED", "Identification failed");
-                    break;
+                    case IDnowSDK.RESULT_CODE_FAILED:
+                        idnowPromise.reject("FAILED", "Identification failed");
+                        break;
 
-                default:
-                    idnowPromise.reject("INTERNAL_ERROR", "Internal error: " + resultCode);
+                    default:
+                        idnowPromise.reject("INTERNAL_ERROR", "Internal error: " + resultCode);
+                }
             }
         }
     };


### PR DESCRIPTION
If a camera result comes back here, make sure it's from IDnow, not from another library.

e.g. when using this library in combination with https://github.com/react-native-image-picker/react-native-image-picker . That image picker will crash upon selecting  or taking a picture, because this class is trying to parse the result.